### PR TITLE
Add AWS ec2 instances page

### DIFF
--- a/src/components.js
+++ b/src/components.js
@@ -22,6 +22,7 @@ import DDCBilling from './components/ddc/Billing.vue';
 import ListS3Buckets from './components/aws/ListS3Buckets.vue';
 import NewS3Bucket from './components/aws/NewS3Bucket.vue';
 import NewS3User from './components/aws/NewS3User.vue';
+import ListEC2Instances from './components/aws/ListEC2Instances.vue';
 // Sematext Components
 import SematextAppList from './components/sematext/AppList.vue';
 import SematextNewApp from './components/sematext/NewApp.vue';
@@ -50,6 +51,7 @@ export const LocalComponents = {
     GrowVolume,
     DDCBilling,
     ListS3Buckets,
+    ListEC2Instances,
     NewS3Bucket,
     NewS3User,
     SematextAppList,

--- a/src/components/aws/ListEC2Instances.vue
+++ b/src/components/aws/ListEC2Instances.vue
@@ -66,20 +66,22 @@
         var nextState;
 
         // check if instance is already changing state
-        if (row.state == 'pending' || row.state == 'stopping') {
+        if (row.state == 'pending' || row.state == 'stopping' || row.state == 'terminated') {
           return
         }
 
         // use running as conditional! the 'else' case should not be stop
         nextState = (row.state == 'running') ? 'stop' : 'start';
-        // change state so that user interface is responsive
-        row.state = (row.state == 'running') ? 'stopping' : 'pending';
 
-        this.$http.post(this.$store.state.backendURL + '/api/aws/ec2/' + row.id + '/' + nextState).then((res) => {
-          row.state = res.body.state;
-        }, () => {
-          row.state = 'unknown';
-        });
+        if (nextState == 'start' || confirm("Are you sure you want to stop " + row.name + "?")) {
+          // change state so that user interface is responsive
+          row.state = (row.state == 'running') ? 'stopping' : 'pending';
+          this.$http.post(this.$store.state.backendURL + '/api/aws/ec2/' + row.id + '/' + nextState).then((res) => {
+            row.state = res.body.state;
+          }, () => {
+            row.state = 'unknown';
+          });
+        }
       },
       getStateIcon: function(row) {
         switch (row.state) {

--- a/src/components/aws/ListEC2Instances.vue
+++ b/src/components/aws/ListEC2Instances.vue
@@ -1,0 +1,122 @@
+<template>
+    <div>
+        <div class="hero is-light">
+            <div class="hero-body">
+                <div class="container">
+                    <h1 class="title"><i class="material-icons">list</i> AWS EC2 Instanzen anzeigen</h1>
+                </div>
+                <h2 class="subtitle">
+                    Hier werden alle deine AWS EC2 Instanzen angezeigt.</h2>
+            </div>
+        </div>
+        <br>
+        <b-table :data="data"
+                 v-bind:class="{'is-loading': loading}"
+                 :narrowed="true">
+
+            <template slot-scope="props">
+                <b-table-column field="name" label="Instance-Name">
+                    {{ props.row.name }}
+                </b-table-column>
+                <b-table-column field="account" label="SBB AWS Account">
+                    {{ props.row.account }}
+                </b-table-column>
+                <b-table-column field="account" label="State">
+                    <b-tooltip :label="getStateLabel(props.row)">
+                        <a v-on:click="toggleState(props.row)">
+                            <b-icon :icon="getStateIcon(props.row)"
+                                    :type="getStateType(props.row)">
+                            </b-icon>
+                        {{ props.row.state }}
+                        </a>
+                    </b-tooltip>
+                </b-table-column>
+            </template>
+
+            <div slot="empty" class="has-text-centered">
+                Hier werden deine Instanzen angezeigt, wenn du welche hast.
+            </div>
+
+        </b-table>
+    </div>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        data: [],
+        loading: false
+      };
+    },
+    mounted: function() {
+        this.listEC2Instances();
+    },
+    methods: {
+      listEC2Instances: function() {
+        this.loading = true;
+        this.$http.get(this.$store.state.backendURL + '/api/aws/ec2').then((res) => {
+          this.data = res.body.instances;
+          this.loading = false;
+        }, () => {
+          this.loading = false;
+        });
+      },
+      toggleState: function(row) {
+        var nextState;
+
+        // check if instance is already changing state
+        if (row.state == 'pending' || row.state == 'stopping') {
+          return
+        }
+
+        // use running as conditional! the 'else' case should not be stop
+        nextState = (row.state == 'running') ? 'stop' : 'start';
+        // change state so that user interface is responsive
+        row.state = (row.state == 'running') ? 'stopping' : 'pending';
+
+        this.$http.post(this.$store.state.backendURL + '/api/aws/ec2/' + row.id + '/' + nextState).then((res) => {
+          row.state = res.body.state;
+        }, () => {
+          row.state = 'unknown';
+        });
+      },
+      getStateIcon: function(row) {
+        switch (row.state) {
+          case 'stopped':
+            return 'circle-outline'
+          case 'running':
+            return 'circle';
+          case 'stopping':
+            return 'arrow-down-drop-circle-outline';
+          case 'pending':
+            return 'arrow-up-drop-circle';
+          default:
+            return 'alert-circle-outline';
+        }
+      },
+      getStateType: function(row) {
+        switch (row.state) {
+          case 'stopped':
+          case 'stopping':
+            return 'is-danger';
+          case 'running':
+          case 'pending':
+            return 'is-success';
+          default:
+            return 'is-danger';
+        }
+      },
+      getStateLabel: function(row) {
+        if (row.state == 'running') {
+          return 'stop';
+        } else if (row.state == 'stopped') {
+          return 'start';
+        } else {
+          // disable tooltip if state is changing
+          return '';
+        }
+      }
+    }
+  }
+</script>

--- a/src/components/shared/Nav.vue
+++ b/src/components/shared/Nav.vue
@@ -54,8 +54,8 @@
                     <div class="navbar-dropdown">
                         <router-link to="/aws/lists3buckets" class="navbar-item">AWS S3 Buckets anzeigen</router-link>
                         <router-link to="/aws/news3bucket" class="navbar-item">AWS S3 Bucket erstellen</router-link>
-                        <router-link to="/aws/news3user" class="navbar-item">AWS S3 Bucket Benutzer erstellen
-                        </router-link>
+                        <router-link to="/aws/news3user" class="navbar-item">AWS S3 Bucket Benutzer erstellen</router-link>
+                        <router-link to="/aws/listec2instances" class="navbar-item">AWS EC2 Instanzen anzeigen</router-link>
                     </div>
                 </div>
                 <div v-if="user" class="navbar-item has-dropdown is-hoverable">

--- a/src/router.js
+++ b/src/router.js
@@ -44,8 +44,12 @@ const routes = [
     },
     {
         path: '/aws/news3bucket', component: LocalComponents.NewS3Bucket
-    }, {
+    },
+    {
         path: '/aws/news3user', component: LocalComponents.NewS3User
+    },
+    {
+        path: '/aws/listec2instances', component: LocalComponents.ListEC2Instances
     },
     {
         path: '/sematext/newapp', component: LocalComponents.SematextNewApp


### PR DESCRIPTION
This is the frontend part of https://github.com/oscp/cloud-selfservice-portal-backend/pull/14. Supported features are:
* list all instances that belong to the logged in user
* start/stop instances (with updating state in the interface)